### PR TITLE
fix typo of tutorial 05 and 07 readme

### DIFF
--- a/tutorial05/tutorial05.md
+++ b/tutorial05/tutorial05.md
@@ -222,7 +222,7 @@ static int lept_parse_value(lept_context* c, lept_value* v) {
 
 3. 使用[第三单元解答篇](../tutorial03_answer/tutorial03_answer.md)介绍的检测内存泄漏工具，会发现测试中有内存泄漏。很明显在 `lept_parse_array()` 中使用到 `malloc()` 分配内存，但却没有对应的 `free()`。应该在哪里释放内存？修改代码，使工具不再检测到相关的内存泄漏。
 
-4. 开启 test.c 中两处被 `#if 0 ... #endif` 关闭的测试，本来 `test_parse_array()` 已经能处理这些测试。然而，运行时会发现 `Assertion failed: (c.top == 0)` 断言失败。这是由于，当错误发生时，仍然有一些临时值在堆栈里，既没有放进数组，也没有被释放。修改 `test_parse_array()`，当遇到错误时，从堆栈中弹出并释放那些临时值，然后才返回错误码。
+4. 开启 test.c 中两处被 `#if 0 ... #endif` 关闭的测试，本来 `lept_parse_array()` 已经能处理这些测试。然而，运行时会发现 `Assertion failed: (c.top == 0)` 断言失败。这是由于，当错误发生时，仍然有一些临时值在堆栈里，既没有放进数组，也没有被释放。修改 `lept_parse_array()`，当遇到错误时，从堆栈中弹出并释放那些临时值，然后才返回错误码。
 
 5. 第 4 节那段代码为什么会有 bug？
 

--- a/tutorial07/tutorial07.md
+++ b/tutorial07/tutorial07.md
@@ -118,7 +118,7 @@ static int lept_stringify_value(lept_context* c, const lept_value* v) {
             break;
 ~~~
 
-但这样需要在 `PUTS()` 中做一次 `memcpy()`，实际上我们可以避免这次复制，只需要生成的时候直接写进 `c` 里的推栈，然后再按实际长度调查 `c->top`：
+但这样需要在 `PUTS()` 中做一次 `memcpy()`，实际上我们可以避免这次复制，只需要生成的时候直接写进 `c` 里的堆栈，然后再按实际长度调查 `c->top`：
 
 ~~~c
         case LEPT_NUMBER:


### PR DESCRIPTION
tutorial05 readme line 225:
原文：本来 **test**_parse_array 已经能处理这些测试
修改：本来 **lept**_parse_array 已经能处理这些测试

tutorial07 readme line 121:
原文：只需要生成的时候直接写进 `c` 里的**推**栈
修改：只需要生成的时候直接写进 `c` 里的**堆**栈