### PR TITLE
Update leptjson.c

### DIFF
--- a/tutorial01_answer/leptjson.c
+++ b/tutorial01_answer/leptjson.c
@@ -63,6 +63,7 @@ int lept_parse(lept_value* v, const char* json) {
         lept_parse_whitespace(&c);
         if (*c.json != '\0')
             ret = LEPT_PARSE_ROOT_NOT_SINGULAR;
+            v->type = LEPT_NULL;
     }
     return ret;
 }


### PR DESCRIPTION
在判断LEPT_PARSE_ROOT_NOT_SINGULAR情况时，如果属于该情况，应当将v->type重置为LEPT_NULL,否则，可能影响测试结果，参照测试代码，如果前面读取到LEPT_FALSE类型，则会判定为一次正确