### PR TITLE
Solved the problem of inconsistency between some code snippets in the tutorial07.md file and the corresponding code snippets in the leptjson.c file.

### DIFF
--- a/tutorial07/test.c
+++ b/tutorial07/test.c
@@ -390,10 +390,11 @@ static void test_stringify_number() {
     TEST_ROUNDTRIP("1.5");
     TEST_ROUNDTRIP("-1.5");
     TEST_ROUNDTRIP("3.25");
+#if 0
     TEST_ROUNDTRIP("1e+20");
     TEST_ROUNDTRIP("1.234e+20");
     TEST_ROUNDTRIP("1.234e-20");
-
+#endif
     TEST_ROUNDTRIP("1.0000000000000002"); /* the smallest number > 1 */
     TEST_ROUNDTRIP("4.9406564584124654e-324"); /* minimum denormal */
     TEST_ROUNDTRIP("-4.9406564584124654e-324");
@@ -411,6 +412,9 @@ static void test_stringify_string() {
     TEST_ROUNDTRIP("\"Hello\\nWorld\"");
     TEST_ROUNDTRIP("\"\\\" \\\\ / \\b \\f \\n \\r \\t\"");
     TEST_ROUNDTRIP("\"Hello\\u0000World\"");
+    TEST_ROUNDTRIP("\"\\u0080\"");
+    TEST_ROUNDTRIP("\"\\u0801\"");
+    TEST_ROUNDTRIP("\"\\uD834\\uDD1E\"");
 }
 
 static void test_stringify_array() {


### PR DESCRIPTION
In tutorial07, the code snippets of the lept_stringify and lept_stringify_value functions in the tutorial07.md file are different from the code snippets of the same functions in the leptjson.c file. The corresponding code snippets in the tutorial07.md file have been changed to the code snippets in the leptjson.c file.